### PR TITLE
Add GitHub buttons to banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,11 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="copydoc" content="https://docs.google.com/document/d/1wqmWPx4TJ_oJoFt4gBOg4trYMIAsugMYtHGXzYJx8kc/edit">
-  
+
   <title>Mir display server - The fast, open and secure display server for any device</title>
+
+  <!-- GitHub buttons -->
+  <script async defer src="https://buttons.github.io/buttons.js"></script>
 
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -75,7 +78,12 @@
         <div class="col-7">
           <h1>The fast, open and secure display server for any device</h1>
           <p>Whether you want an information kiosk, digital signage display, in-car entertainment stack, or home automation interface, Mir on Ubuntu is your fastest path to deployment.</p>
-          <p><a href="https://assets.ubuntu.com/v1/bd787c8a-canonical-mir-datasheet-2018-12-20.pdf" class="p-button--positive"><span class="p-link--external">Get the Mir datasheet</span></a></p>
+          <p class="u-sv3"><a href="https://assets.ubuntu.com/v1/bd787c8a-canonical-mir-datasheet-2018-12-20.pdf" class="p-button--positive"><span class="p-link--external">Get the Mir datasheet</span></a></p>
+          <div>
+            <a class="github-button" data-size="large" href="https://github.com/MirServer/mir" aria-label="Follow @MirServer on GitHub"></a>
+            <a class="github-button" data-size="large" href="https://github.com/MirServer/mir" data-icon="octicon-star" data-show-count="true" aria-label="Star MirServer/mir on GitHub"></a>
+            <a class="github-button" data-size="large" href="https://github.com/MirServer/mir/fork" data-icon="octicon-repo-forked" data-show-count="true" aria-label="Fork MirServer/mir on GitHub"></a>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Done

Add GitHub buttons to site

## QA

- Download this branch
- Go to http://0.0.0.0:8028/
- See the buttons and make sure they go to the right repo

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1601

## Screenshots

![image](https://user-images.githubusercontent.com/441217/64845964-5755d680-d603-11e9-9767-106da2a8225d.png)
