### PR TITLE
Multistage builds and fix /docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,9 @@
 cache.sqlite
 README.md
 HACKING.md
+renovate.json
+LICENCE
+.sass-lint.yml
 
 # The run script isn't needed
 run
@@ -19,6 +22,4 @@ run
 .env.local
 
 # Node is only needed for building, not running
-package.json
 node_modules
-yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,55 @@
-FROM ubuntu:bionic
+# syntax=docker/dockerfile:experimental
 
-RUN apt-get update && apt-get install --yes nginx
-
-# Set git commit ID
-ARG REVISION_ID
-RUN test -n "${REVISION_ID}"
-
-# Copy over files
+# Build stage: Install ruby dependencies
+# ===
+FROM ruby:2.5 AS build-site
 WORKDIR /srv
-ADD _site .
+ADD . .
+RUN bundle install
+RUN bundle exec jekyll build
+
+# Build stage: Install yarn dependencies
+# ===
+FROM node:12-slim AS yarn-dependencies
+WORKDIR /srv
+ADD package.json .
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
+
+# Build stage: Run "yarn run build-js"
+# ===
+FROM yarn-dependencies AS build-js
+WORKDIR /srv
+ADD . .
+RUN yarn run build-js
+
+# Build stage: Run "yarn run build-css"
+# ===
+FROM yarn-dependencies AS build-css
+WORKDIR /srv
+ADD . .
+RUN yarn run build-css
+
+# Build the production image
+# ===
+FROM ubuntu:focal
+
+# Set up environment
+ENV LANG C.UTF-8
+WORKDIR /srv
+
+# Install nginx
+RUN apt-get update && apt-get install --no-install-recommends --yes nginx
+
+# Import code, build assets and mirror list
+RUN rm -rf package.json yarn.lock .babelrc webpack.config.js Gemfile.lock nginx.conf
+COPY --from=build-site srv/_site .
+COPY --from=build-css srv/build build
+COPY --from=build-js srv/src/js src/js
+
+ARG BUILD_ID
 ADD nginx.conf /etc/nginx/sites-enabled/default
-RUN sed -i "s/~REVISION_ID~/${REVISION_ID}/" /etc/nginx/sites-enabled/default
+RUN sed -i "s/~BUILD_ID~/${BUILD_ID}/" /etc/nginx/sites-enabled/default
 
 STOPSIGNAL SIGTERM
 
 CMD ["nginx", "-g", "daemon off;"]
-

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
             <a href="doc/getting_and_using_mir.html">User manual</a>
           </li>
           <li class="p-navigation__link" role="menuitem">
-            <a href="doc">Developer manual</a>
+            <a href="/doc/">Developer manual</a>
           </li>
         </ul>
       </nav>

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,7 +14,7 @@ server {
     error_page 404 /404.html;
 
     # Show commit-id
-    add_header x-vcs-revision ~REVISION_ID~ always;
+    add_header x-vcs-revision ~BUILD_ID~ always;
     add_header x-hostname $hostname always;
 
     server_name _;


### PR DESCRIPTION
## Done

Multistage builds to decrease image size, faster image building.

## QA

- `export DOCKER_BUILDKIT=1`
- Build image with new dockerfile `docker build --tag myimage --build-arg BUILD_ID=myfakeid .`
- Run conainter with this image `docker run -ti -p 8111:80 myimage`
- Check build_id `myfakeid` is present `curl localhost:8111`

## Issue / Card
Fixes #53 
