### PR TITLE
Integrate cookie-policy v3.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "yarn run build-css && yarn run build-js && yarn run build-site",
     "build-site": "eleventy --formats=html,css,js,map,svg --input=src --output=_site",
     "build-css": "node-sass --include-path node_modules src/sass --source-map true --output-style compressed --output src/css && postcss --use autoprefixer --replace 'src/css/**/*.css'",
-    "build-js": "mkdir -p src/js/build/ && cp node_modules/@canonical/global-nav/dist/global-nav.js src/js/build/",
+    "build-js": "yarn run copy-cookie-policy && yarn run copy-global-nav",
+    "copy-cookie-policy": "mkdir -p src/js/build && cp node_modules/@canonical/cookie-policy/build/js/cookie-policy.js src/js/build",
+    "copy-global-nav": "mkdir -p src/js/build && cp node_modules/@canonical/global-nav/dist/global-nav.js src/js/build",
     "watch-css": "watch -p 'src/sass/**/*.scss' -c 'yarn run build-css'",
     "watch-js": "watch -p 'node_modules/global-nav/dist/index.js' -c 'yarn run build-js'",
     "serve": "eleventy --formats=html,scss,css,js,map,svg --input=src --output=_site --watch --serve --port $PORT",
@@ -15,6 +17,7 @@
   },
   "dependencies": {
     "@canonical/global-nav": "2.4.3",
+    "@canonical/cookie-policy": "3.0.4",
     "postcss": "8.1.1",
     "vanilla-framework": "2.19.1"
   },

--- a/src/index.html
+++ b/src/index.html
@@ -225,6 +225,9 @@
                 </a>
               </li>
               <li class="p-inline-list__item">
+                <a class="js-revoke-cookie-manager" href="">Manage your tracker settings</a>
+              </li>
+              <li class="p-inline-list__item">
                 <a aria-label="External link to report a bug on this site"
                   href="https://github.com/canonical-websites/mir-server.io/issues/new">
                   Report a bug on this site
@@ -301,8 +304,12 @@ function sendEvent(category, origin, destination, label) {
   }
 }
 
-  </script> 
-  <script>canonicalGlobalNav.createNav({maxWidth: '72rem'});</script>
+  </script>
+  <script src="/js/build/cookie-policy.js"></script>
+  <script>
+    cpNs.cookiePolicy();
+    canonicalGlobalNav.createNav({maxWidth:"72rem"});
+  </script>
 </body>
 
 </html>

--- a/src/sass/styles.scss
+++ b/src/sass/styles.scss
@@ -3,6 +3,9 @@
 
 @include vanilla;
 
+// import cookie policy
+@import "@canonical/cookie-policy/build/css/cookie-policy";
+
 $strip-gradient: linear-gradient(195deg, #e9500e 0%, #6e2953 34%, #25001e 100%);
 
 .p-strip--hero {

--- a/yarn.lock
+++ b/yarn.lock
@@ -236,6 +236,11 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@canonical/cookie-policy@3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.4.tgz#c2d6d990dc0993344a9bf5c244374e3f51fe34f1"
+  integrity sha512-pI65cRFh9xU2xo3d9R8ifGbQoH72tk3p8xh/4ANuj9kREeh9G/gcim/iHQS7IffSocHT9l6ZtUXBcQ12m/CBMw==
+
 "@canonical/global-nav@2.4.3":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@canonical/global-nav/-/global-nav-2.4.3.tgz#9d552bad1968537c4b952747b27d5d3db21cf327"


### PR DESCRIPTION
## Done
- Integrate cookie policy 3.0.4

## QA
- Pull the branch
- Run the site using the dotrun snap with `$ dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8028/
- Check the cookie policy appears
- Check the manager opens and works
- Make a selection and the notification should disappear
- Scroll to the footer and click the Manage link in the footer
- See that manager appears again. 

## Issue / Card
Fixes #75 