### PR TITLE
Replace freenode with libera.chat

### DIFF
--- a/doc/getting_involved_in_mir.html
+++ b/doc/getting_involved_in_mir.html
@@ -52,7 +52,7 @@ $(function() {
 
 <!-- iframe showing the search results (closed by default) -->
 <div id="MSearchResultsWindow">
-<iframe src="javascript:void(0)" frameborder="0" 
+<iframe src="javascript:void(0)" frameborder="0"
         name="MSearchResults" id="MSearchResults">
 </iframe>
 </div>
@@ -64,9 +64,9 @@ $(function() {
 </div><!--header-->
 <div class="contents">
 <div class="textblock"><h2>Getting involved</h2>
-<p>The Mir project website is <a href="http://www.mirserver.io/">http://www.mirserver.io/</a>, the code is <a href="https://github.com/MirServer">hosted on GitHub</a></p>
+<p>The Mir project website is <a href="https://mirserver.io">mirserver.io</a>, the code is <a href="https://github.com/MirServer">hosted on GitHub</a></p>
 <p>For announcements and other discussions on Mir see: <a href="https://community.ubuntu.com/c/mir">Mir on community.ubuntu</a></p>
-<p>For other questions and discussion about the Mir project: the #mirserver IRC channel on freenode.</p>
+<p>For other questions and discussion about the Mir project: the <code>#mirserver</code> IRC channel on <a href="https://libera.chat">Libera Chat</a>.</p>
 <h2>Getting Mir source and dependencies</h2>
 <h3>On Ubuntu</h3>
 <p>You’ll need a few development tools installed: </p><pre class="fragment">sudo apt install devscripts equivs git

--- a/src/index.html
+++ b/src/index.html
@@ -209,7 +209,7 @@
             </div>
             <p>Get connected.</p>
             <p><a class="p-link--external" href="https://community.ubuntu.com/c/mir">Mir in the Ubuntu Community forum</a></p>
-            <p><a class="p-link--external" href="https://webchat.freenode.net/?channels=%23mir-server">#mir-server on Freenode</a></p>
+            <p><a href="https://libera.chat" class="p-link--external">Join <code>#mir-server</code> on Libera Chat</a></p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Done 

Replace freenode with libera.chat

## QA

- See that libera chat is in the footer and on the /doc/getting_involved_in_mir page

## Screenshot

![image](https://user-images.githubusercontent.com/441217/122550568-bdb72680-d02b-11eb-95c1-6355a6b237f5.png)
