### PR TITLE
Add a 404 error page

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,3 +1,21 @@
+const fs = require("fs");
+
 module.exports = function (eleventyConfig) {
   eleventyConfig.setUseGitIgnore(false);
+
+  eleventyConfig.setBrowserSyncConfig({
+    callbacks: {
+      ready: function(err, bs) {
+
+        bs.addMiddleware("*", (req, res) => {
+          const content_404 = fs.readFileSync('_site/404/index.html');
+          // Add 404 http status code in request header.
+          res.writeHead(404, { "Content-Type": "text/html; charset=UTF-8" });
+          // Provides the 404 content without redirect.
+          res.write(content_404);
+          res.end();
+        });
+      }
+    }
+  });
 };

--- a/src/404.html
+++ b/src/404.html
@@ -1,0 +1,18 @@
+---
+layout: base_layout
+title: "404: Page not found"
+---
+
+{% block content %}
+<section class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-6">
+      <img src="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg?w=365" alt="" width="365">
+    </div>
+    <div class="col-6">
+      <h1>404: Page not found</h1>
+      <p>Sorry, we couldn’t find that page.</p>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/src/404.html
+++ b/src/404.html
@@ -1,6 +1,7 @@
 ---
 layout: base_layout
 title: "404: Page not found"
+permalink: 404.html
 ---
 
 {% block content %}


### PR DESCRIPTION
## Done
Added a 404 template page and configured the site to render it when hitting a page that is not found.

## QA
- Open the demo and view the homepage is rendered
- Go to a random path such as /nope and see the 404 pages is rendered

Fixes https://github.com/canonical-web-and-design/mir-server.io/issues/124