### PR TITLE
Added a community link in the header & copy update

### DIFF
--- a/src/_includes/base_layout.html
+++ b/src/_includes/base_layout.html
@@ -71,6 +71,9 @@
           <li class="p-navigation__link" role="menuitem">
             <a href="/tutorials/">Tutorials</a>
           </li>
+          <li class="p-navigation__link" role="menuitem">
+            <a class="p-link--external" href="https://discourse.ubuntu.com/c/mir">Community</a>
+          </li>
         </ul>
       </nav>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -27,7 +27,7 @@ metadata: Mir is the fast, open and secure display server to unlock next-generat
       <h2>What is Mir?</h2>
       <p class="p-heading--4">Introducing a secure display server for IoT devices</p>
       <p>Mir is a system-level component that can be used to unlock next-generation user experiences. It runs on a range of Linux powered devices including traditional desktops, IoT and embedded products. Mir is a replacement for the X window server system, commonly used on Linux desktop devices. It allows device makers and desktop users to have a well-defined, efficient, flexible, and secure platform for their graphical environment.</p>
-      <p><a href="https://ubuntu.com/blog/build-smart-display-devices-with-mir-fast-to-production-secure-open-source" class="p-button--positive"><span class="p-link--external">Download the whitepaper</span></a></p>
+      <p><a href="https://ubuntu.com/engage/build-smart-devices-with-mir-whitepaper" class="p-button--positive"><span class="p-link--external">Download the whitepaper</span></a></p>
     </div>
     <div class="col-3 u-hide--small u-align--center u-vertically-center">
       <img src="https://assets.ubuntu.com/v1/8c0acddd-Mir.svg" alt="Mir Server wordmark" width="400"/>


### PR DESCRIPTION
## Done

- Added a link to the discourse forum in the header
- Updated a link in the main page as requested in the [copy doc](https://docs.google.com/document/d/1wqmWPx4TJ_oJoFt4gBOg4trYMIAsugMYtHGXzYJx8kc/edit)

## QA

- Go to the website https://mir-server-io-133.demos.haus/
- Make sure that the link of the button "Download the whitepaper" is updated, as requested in the [copy doc](https://docs.google.com/document/d/1wqmWPx4TJ_oJoFt4gBOg4trYMIAsugMYtHGXzYJx8kc/edit) and please resolve the discussion once reviewed
- Make sure that the community link is added to the header

## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/10507

## Screenshots

### The new item in the navbar

![Screenshot from 2021-09-27 17-25-40](https://user-images.githubusercontent.com/36013798/134938295-2dd17fb8-cbc3-4267-9299-9250dd5087bc.png)

